### PR TITLE
Reversing the stack for easier use with A* and its companions

### DIFF
--- a/minecraft/suit/Directions.c
+++ b/minecraft/suit/Directions.c
@@ -47,13 +47,13 @@ void getInstructions(float angle) {
 void giveDirections(struct Stack* stack) {
 	struct Location* loc = (struct Location*)malloc(sizeof(struct Location*));
 	mcGetLocation(loc);
-		
+	//why do I need to pop this???? wtf
+	pop(stack);
 	struct Node* node = pop(stack);
 	struct Node* lastNode = node;
 	float angle = 0;
 
 	while (!isStackEmpty(stack)) {
-		printf("%d is the stack's current top index\n", stack->top);
 		mcStartUpsertGraph();
 		mcUpsertNode(node->ID, 0, 0, 0, 0xFF'41'FF'FF, 0.025F);
 		mcUpsertEdge(node->ID, lastNode->ID, 0xFF'41'FF'FF);
@@ -64,10 +64,10 @@ void giveDirections(struct Stack* stack) {
 			angle = relativeToPlayer(loc, node);
 
 			getInstructions(angle);
-			Sleep(100);
+			Sleep(1000);
 			mcGetLocation(loc);
 		}
-		Sleep(5);
+		Sleep(1000);
 		lastNode = node;
 		node = pop(stack);
 		mcGetLocation(loc);

--- a/minecraft/suit/Graph.c
+++ b/minecraft/suit/Graph.c
@@ -16,7 +16,7 @@ struct Graph* createGraph(){
 struct Node* createNode(int id, float x, float y, float z){
     struct Node* node = malloc(sizeof(struct Node));
     if (node == NULL) {
-        printf("Failure lmao\n");
+        printf("How did you fuck this up? You're just creating a node. All the info is there! Ridiculous.\n");
     }
     else {
         node->ID = id; //by default
@@ -32,15 +32,23 @@ struct Node* createNode(int id, float x, float y, float z){
     return node;
 }
 
+/*
+* It occured to me that it would make my life so much easier if
+* I reversed the direction of the node edges. Think about it:
+* Having them go backwards means I don't have to search from every
+* starting node. Instead, by virtue of how A* works, it'll find the 
+* closest exit node.
+*/
 void addNode(struct Graph* graph, struct Node* node){
     if (graph->used == 0){
         graph->nodes[0] = node;
         graph->used++;
     }
     else{
-        graph->nodes[graph->used - 1]->adjacencyArray[0] = node; //-1 is because the adjacency array of the previous node is being set
-        graph->nodes[graph->used - 1]->adjacent++;
+        // Now the ordering is node_n -> node_{n-1} instead of node_{n-1} -> node_n
         graph->nodes[graph->used] = node;
+        graph->nodes[graph->used]->adjacencyArray[0] = graph->nodes[graph->used - 1]; 
+        graph->nodes[graph->used]->adjacent++;
         graph->used++;
     }
 }

--- a/minecraft/suit/GraphRecreation.c
+++ b/minecraft/suit/GraphRecreation.c
@@ -17,21 +17,21 @@ struct Stack* simplePathRecreation(struct Graph* graph) {
 	findAdjecencies(graph);
 	printGraph(graph);
 	struct Stack* path = createStack(graph->used);
+	struct Stack* pathProper = createStack(graph->used);
 	//Current node ID
-	int currID = graph->nodes[0]->ID;
+	int currID = graph->nodes[graph->used-1]->ID;
 	//Number of elements in the current node
-	int elements = graph->nodes[0]->adjacent;
+	int elements = graph->nodes[graph->used-1]->adjacent;
 
 	do {
 		push(path, graph->nodes[currID]);
 		elements = graph->nodes[currID]->adjacent - 1;
-		if (currID == graph->used - 1) {
-			break;
-		}
-		else {
+		if (currID != 0) {
 			currID = graph->nodes[currID]->adjacencyArray[elements]->ID;
 		}
-	} while (currID <= graph->used - 1);
+	} while (currID > 0);
 	
-	return path;
+	pathProper = reverseStack(path);
+
+	return pathProper;
 }

--- a/minecraft/suit/Main.c
+++ b/minecraft/suit/Main.c
@@ -39,13 +39,14 @@ int main() {
 
 	mcStartUpsertGraph();
 
-	for (int i = pathBack->top; i > 0; i--) {
+	for (int i = pathBack->top - 1; i > 0; i--) {
 		current = pathBack->array[i];
 		next = pathBack->array[i - 1];
-		printf("%d->%d\n", next->ID, current->ID);
+		printf("%d->%d\n", current->ID, next->ID);
 		mcUpsertNode(current->ID, 0, 0, 0, GREEN, 0.025);
 		mcUpsertEdge(next->ID, current->ID, GREEN);
 	}
+
 	// Upsert last node (`next` in the last iteration is never drawn)
 	current = pathBack->array[0];
 	mcUpsertNode(current->ID, 0, 0, 0, GREEN, 0.025);

--- a/minecraft/suit/Octree.c
+++ b/minecraft/suit/Octree.c
@@ -199,7 +199,7 @@ void recurseOctree(struct Octree* octree, struct Node* node) {
     //base case: has reached a leaf with nodes
     if (octree->leaf) {
         for (int i = 0; i < octree->nodeNum; i++) {
-            if (distance(node, octree->nodes[i]) < 4 && !inAdjacencies(node, octree->nodes[i]) && node->ID != octree->nodes[i]->ID && node->ID < octree->nodes[i]->ID) {
+            if (distance(node, octree->nodes[i]) < 4 && !inAdjacencies(node, octree->nodes[i]) && node->ID != octree->nodes[i]->ID && node->ID >= octree->nodes[i]->ID) {
                 node->adjacencyArray[node->adjacent] = octree->nodes[i];
                 node->adjacent++;
             }
@@ -208,7 +208,6 @@ void recurseOctree(struct Octree* octree, struct Node* node) {
     //recursive case: must recurse through the children
     else if(octree->children[0]){
         for (int i = 0; i < 8; i++) {
-            printf("Xbound: %f\n", octree->children[i]->bounds->xmax);
             //check bounds, eliminate octants that aren't needed
             if (isInBounds(octree->children[i]->bounds, node)  || checkNearbyOctants(octree->children[i]->bounds, node)) {
                 recurseOctree(octree->children[i], node);

--- a/minecraft/suit/Stack.c
+++ b/minecraft/suit/Stack.c
@@ -34,7 +34,20 @@ struct Node* peek(struct Stack* stack) {
     return !isStackEmpty(stack) ? stack->array[stack->top] : NULL;
 }
 
+
 void freeStack(struct Stack* stack) {
     free(stack->array);
     free(stack);
+}
+
+struct Stack* reverseStack(struct Stack* original) {
+    struct Stack* stack = createStack(original->capacity);
+
+    while (!isStackEmpty(original)) {
+        struct Node* node = pop(original);
+        push(stack, node);
+    }
+    freeStack(original);
+    printf("%d\n", stack->top);
+    return stack;
 }

--- a/minecraft/suit/Stack.h
+++ b/minecraft/suit/Stack.h
@@ -19,5 +19,7 @@ struct Node* pop(struct Stack* stack);
 struct Node* peek(struct Stack* stack);
 
 void freeStack(struct Stack* stack);
+/*Just reverses the stack. Useful for current direction of edges.*/
+struct Stack* reverseStack(struct Stack* original);
 
 #endif


### PR DESCRIPTION
A quick fix that changes the way the edges work. The directions are now from ID -> ID-1.